### PR TITLE
Test: Fix names for scaling macros and improve them

### DIFF
--- a/Test/deque_test.h
+++ b/Test/deque_test.h
@@ -76,17 +76,17 @@ void deque_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|     push_front      |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(deque<int>, push_front, rand(), LEN1 _LL, LEN2 _LL, LEN3 _LL);
+  CON_TEST_P1(deque<int>, push_front, rand(), SCALE_LL(LEN1), SCALE_LL(LEN2), SCALE_LL(LEN3));
 #else
-  CON_TEST_P1(deque<int>, push_front, rand(), LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P1(deque<int>, push_front, rand(), SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|     push_back       |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(deque<int>, push_back, rand(), LEN1 _LL, LEN2 _LL, LEN3 _LL);
+  CON_TEST_P1(deque<int>, push_back, rand(), SCALE_LL(LEN1), SCALE_LL(LEN2), SCALE_LL(LEN3));
 #else
-  CON_TEST_P1(deque<int>, push_back, rand(), LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P1(deque<int>, push_back, rand(), SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;

--- a/Test/list_test.h
+++ b/Test/list_test.h
@@ -92,17 +92,17 @@ void list_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|       insert        |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P2(list<int>, insert, end, rand(), LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P2(list<int>, insert, end, rand(), SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #else
-  CON_TEST_P2(list<int>, insert, end, rand(), LEN1 _M, LEN2 _M, LEN3 _M);
+  CON_TEST_P2(list<int>, insert, end, rand(), SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|         sort        |";
 #if LARGER_TEST_DATA_ON
-  LIST_SORT_TEST(LEN1 _M, LEN2 _M, LEN3 _M);
+  LIST_SORT_TEST(SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #else
-  LIST_SORT_TEST(LEN1 _S, LEN2 _S, LEN3 _S);
+  LIST_SORT_TEST(SCALE_S(LEN1), SCALE_S(LEN2), SCALE_S(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;

--- a/Test/map_test.h
+++ b/Test/map_test.h
@@ -108,9 +108,9 @@ void map_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|       emplace       |";
 #if LARGER_TEST_DATA_ON
-  MAP_EMPLACE_TEST(map, LEN1 _L, LEN2 _L, LEN3 _L);
+  MAP_EMPLACE_TEST(map, SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #else
-  MAP_EMPLACE_TEST(map, LEN1 _M, LEN2 _M, LEN3 _M);
+  MAP_EMPLACE_TEST(map, SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
@@ -184,9 +184,9 @@ void multimap_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|       emplace       |";
 #if LARGER_TEST_DATA_ON
-  MAP_EMPLACE_TEST(multimap, LEN1 _M, LEN2 _M, LEN3 _M);
+  MAP_EMPLACE_TEST(multimap, SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #else
-  MAP_EMPLACE_TEST(multimap, LEN1 _S, LEN2 _S, LEN3 _S);
+  MAP_EMPLACE_TEST(multimap, SCALE_S(LEN1), SCALE_S(LEN2), SCALE_S(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;

--- a/Test/queue_test.h
+++ b/Test/queue_test.h
@@ -110,9 +110,9 @@ void queue_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|         push        |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(queue<int>, push, rand(), LEN1 _LL, LEN2 _LL, LEN3 _LL);
+  CON_TEST_P1(queue<int>, push, rand(), SCALE_LL(LEN1), SCALE_LL(LEN2), SCALE_LL(LEN3));
 #else
-  CON_TEST_P1(queue<int>, push, rand(), LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P1(queue<int>, push, rand(), SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
@@ -168,9 +168,9 @@ void priority_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|         push        |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(priority_queue<int>, push, rand(), LEN1 _LL, LEN2 _LL, LEN3 _LL);
+  CON_TEST_P1(priority_queue<int>, push, rand(), SCALE_LL(LEN1), SCALE_LL(LEN2), SCALE_LL(LEN3));
 #else
-  CON_TEST_P1(priority_queue<int>, push, rand(), LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P1(priority_queue<int>, push, rand(), SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;

--- a/Test/set_test.h
+++ b/Test/set_test.h
@@ -76,9 +76,9 @@ void set_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|       emplace       |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(set<int>, emplace, rand(), LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P1(set<int>, emplace, rand(), SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #else
-  CON_TEST_P1(set<int>, emplace, rand(), LEN1 _M, LEN2 _M, LEN3 _M);
+  CON_TEST_P1(set<int>, emplace, rand(), SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
@@ -148,9 +148,9 @@ void multiset_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|       emplace       |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(multiset<int>, emplace, rand(), LEN1 _M, LEN2 _M, LEN3 _M);
+  CON_TEST_P1(multiset<int>, emplace, rand(), SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #else
-  CON_TEST_P1(multiset<int>, emplace, rand(), LEN1 _S, LEN2 _S, LEN3 _S);
+  CON_TEST_P1(multiset<int>, emplace, rand(), SCALE_S(LEN1), SCALE_S(LEN2), SCALE_S(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;

--- a/Test/stack_test.h
+++ b/Test/stack_test.h
@@ -85,9 +85,9 @@ void stack_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|         push        |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(stack<int>, push, rand(), LEN1 _LL, LEN2 _LL, LEN3 _LL);
+  CON_TEST_P1(stack<int>, push, rand(), SCALE_LL(LEN1), SCALE_LL(LEN2), SCALE_LL(LEN3));
 #else
-  CON_TEST_P1(stack<int>, push, rand(), LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P1(stack<int>, push, rand(), SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;

--- a/Test/string_test.h
+++ b/Test/string_test.h
@@ -190,9 +190,9 @@ void string_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|        append       |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(string, append, "s", LEN1 _LL, LEN2 _LL, LEN3 _LL);
+  CON_TEST_P1(string, append, "s", SCALE_LL(LEN1), SCALE_LL(LEN2), SCALE_LL(LEN3));
 #else
-  CON_TEST_P1(string, append, "s", LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P1(string, append, "s", SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;

--- a/Test/test.h
+++ b/Test/test.h
@@ -512,13 +512,13 @@ EXPECT_CON_EQ(v1, v3)   ok
 #define LEN3    10000000
 #endif
 
-#define _LLL * 20
-#define _LL  * 10
-#define _L   * 5
-#define _M
-#define _S   / 5
-#define _SS  / 10
-#define _SSS / 20
+#define SCALE_LLL(N) (N * 20)
+#define SCALE_LL(N)  (N * 10)
+#define SCALE_L(N)   (N * 5)
+#define SCALE_M(N)   (N)
+#define SCALE_S(N)   (N / 5)
+#define SCALE_SS(N)  (N / 10)
+#define SCALE_SSS(N) (N / 20)
 
 #define WIDE    14
 

--- a/Test/unordered_map_test.h
+++ b/Test/unordered_map_test.h
@@ -96,9 +96,9 @@ void unordered_map_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|       emplace       |";
 #if LARGER_TEST_DATA_ON
-  MAP_EMPLACE_TEST(unordered_map, LEN1 _M, LEN2 _M, LEN3 _M);
+  MAP_EMPLACE_TEST(unordered_map, SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #else
-  MAP_EMPLACE_TEST(unordered_map, LEN1 _S, LEN2 _S, LEN3 _S);
+  MAP_EMPLACE_TEST(unordered_map, SCALE_S(LEN1), SCALE_S(LEN2), SCALE_S(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
@@ -185,9 +185,9 @@ void unordered_multimap_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|       emplace       |";
 #if LARGER_TEST_DATA_ON
-  MAP_EMPLACE_TEST(unordered_multimap, LEN1 _M, LEN2 _M, LEN3 _M);
+  MAP_EMPLACE_TEST(unordered_multimap, SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #else
-  MAP_EMPLACE_TEST(unordered_multimap, LEN1 _S, LEN2 _S, LEN3 _S);
+  MAP_EMPLACE_TEST(unordered_multimap, SCALE_S(LEN1), SCALE_S(LEN2), SCALE_S(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;

--- a/Test/unordered_set_test.h
+++ b/Test/unordered_set_test.h
@@ -89,9 +89,9 @@ void unordered_set_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|       emplace       |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(unordered_set<int>, emplace, rand(), LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P1(unordered_set<int>, emplace, rand(), SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #else
-  CON_TEST_P1(unordered_set<int>, emplace, rand(), LEN1 _M, LEN2 _M, LEN3 _M);
+  CON_TEST_P1(unordered_set<int>, emplace, rand(), SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
@@ -173,9 +173,9 @@ void unordered_multiset_test()
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;
   std::cout << "|       emplace       |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(unordered_multiset<int>, emplace, rand(), LEN1 _M, LEN2 _M, LEN3 _M);
+  CON_TEST_P1(unordered_multiset<int>, emplace, rand(), SCALE_M(LEN1), SCALE_M(LEN2), SCALE_M(LEN3));
 #else
-  CON_TEST_P1(unordered_multiset<int>, emplace, rand(), LEN1 _S, LEN2 _S, LEN3 _S);
+  CON_TEST_P1(unordered_multiset<int>, emplace, rand(), SCALE_S(LEN1), SCALE_S(LEN2), SCALE_S(LEN3));
 #endif
   std::cout << std::endl;
   std::cout << "|---------------------|-------------|-------------|-------------|" << std::endl;

--- a/Test/vector_test.h
+++ b/Test/vector_test.h
@@ -96,9 +96,9 @@ void vector_test()
   std::cout << "|---------------------|-------------|-------------|-------------|\n";
   std::cout << "|      push_back      |";
 #if LARGER_TEST_DATA_ON
-  CON_TEST_P1(vector<int>, push_back, rand(), LEN1 _LL, LEN2 _LL, LEN3 _LL);
+  CON_TEST_P1(vector<int>, push_back, rand(), SCALE_LL(LEN1), SCALE_LL(LEN2), SCALE_LL(LEN3));
 #else
-  CON_TEST_P1(vector<int>, push_back, rand(), LEN1 _L, LEN2 _L, LEN3 _L);
+  CON_TEST_P1(vector<int>, push_back, rand(), SCALE_L(LEN1), SCALE_L(LEN2), SCALE_L(LEN3));
 #endif
   std::cout << "\n";
   std::cout << "|---------------------|-------------|-------------|-------------|\n";


### PR DESCRIPTION
Fixes #107.

Fixing names for scaling macros:
- old names (reserved): `_LLL`, `_LL`, `_L`, `_M`, `_S`, `_SS`, `_SSS`;
- new names: `SCALE_LLL`, `SCALE_LL`, `SCALE_L`, `SCALE_M`, `SCALE_S`, `SCALE_SS`, `SCALE_SSS`.

Changing these macros to function-like macros to prohibit some misusages.

修复乘数宏的名字：
- 旧名（受保留）： `_LLL`、 `_LL`、 `_L`、 `_M`、 `_S`、 `_SS`、 `_SSS` ；
- 新名： `SCALE_LLL`、 `SCALE_LL`、 `SCALE_L`、 `SCALE_M`、 `SCALE_S`、 `SCALE_SS`、 `SCALE_SSS` 。

更改这些宏为仿函数宏以禁止一些误用。

Could you have a look? @StephanTLavavej @Alinshans 