### PR TITLE
fix reads out of bounds in tests

### DIFF
--- a/Test/algorithm_test.h
+++ b/Test/algorithm_test.h
@@ -633,10 +633,10 @@ TEST(inplace_merge_test)
 
 TEST(is_heap_test)
 {
-  int arr1[] = { 1,2,3,4,5,6,7,8,9 };
-  int arr2[] = { 9,8,7,6,5,4,3,2,1 };
-  int arr3[] = { 1,3,5,7,9,2,4,6,8 };
-  int arr4[] = { 1,2,3,4,5,6,7,8,9 };
+  int arr1[] = { 0,1,2,3,4,5,6,7,8,9 };
+  int arr2[] = { 9,8,7,6,5,4,3,2,1,0 };
+  int arr3[] = { 1,3,5,7,9,0,2,4,6,8 };
+  int arr4[] = { 0,1,2,3,4,5,6,7,8,9 };
   std::make_heap(arr4, arr4 + 10);
   EXPECT_EQ(std::is_heap(arr1, arr1 + 10), mystl::is_heap(arr1, arr1 + 10));
   EXPECT_EQ(std::is_heap(arr2, arr2 + 10, std::less<int>()),
@@ -1179,4 +1179,3 @@ TEST(upper_bound_test)
 } // namespace test
 } // namespace mystl
 #endif // !MYTINYSTL_ALGORITHM_TEST_H_
-

--- a/Test/string_test.h
+++ b/Test/string_test.h
@@ -92,7 +92,7 @@ void string_test()
   FUN_VALUE(str.compare("zzz"));
   FUN_VALUE(str.compare(0, 3, "str"));
   FUN_VALUE(str.compare(0, 3, "stri", 4));
-  FUN_VALUE(str.compare(0, 3, "s", 3));
+  FUN_VALUE(str.compare(0, 3, "s", 2));
   FUN_VALUE(str.compare(0, 9, "stringabc", 9));
   FUN_VALUE(str.substr(0));
   FUN_VALUE(str.substr(3));
@@ -205,4 +205,3 @@ void string_test()
 } // namespace test
 } // namespace mystl
 #endif // !MYTINYSTL_STRING_TEST_H_
-


### PR DESCRIPTION
in algorithm_test.h, we were reading one past the end of the arrays

in string_test.h, we were reading one past the end of a string literal

Found by use of [/fsanitize=address][]

[/fsanitize=address]: https://devblogs.microsoft.com/cppblog/asan-for-windows-x64-and-debug-build-support/