### PR TITLE
range_init 使用distance判断迭代器之间距离

### DIFF
--- a/MyTinySTL/vector.h
+++ b/MyTinySTL/vector.h
@@ -603,9 +603,9 @@ template <class Iter>
 void vector<T>::
 range_init(Iter first, Iter last)
 {
-  const size_type init_size = mystl::max(static_cast<size_type>(last - first),
-                                         static_cast<size_type>(16));
-  init_space(static_cast<size_type>(last - first), init_size);
+  const size_type len = mystl::distance(first, last);
+  const size_type init_size = mystl::max(len, static_cast<size_type>(16));
+  init_space(len, init_size);
   mystl::uninitialized_copy(first, last, begin_);
 }
 


### PR DESCRIPTION
 `template <class Iter, typename std::enable_if<
    mystl::is_input_iterator<Iter>::value, int>::type = 0>
  vector(Iter first, Iter last)` 函数内部调用 `range_init` 函数，由于不确定迭代器类型，因此需要用 `distance` 计算距离。