### PR TITLE
`algorithm_test.h`: Fix uses of `std::` and `mystl::` in `unique_test`

### DIFF
--- a/Test/algorithm_test.h
+++ b/Test/algorithm_test.h
@@ -1136,7 +1136,7 @@ TEST(unique_test)
   std::unique(arr1, arr1 + 10);
   mystl::unique(arr2, arr2 + 10);
   std::unique(arr3, arr3 + 9, std::equal_to<int>());
-  std::unique(arr4, arr4 + 9, std::equal_to<int>());
+  mystl::unique(arr4, arr4 + 9, std::equal_to<int>());
   EXPECT_CON_EQ(arr1, arr2);
   EXPECT_CON_EQ(arr3, arr4);
 }


### PR DESCRIPTION
Fixes #122.

We should call `mystl::unique` in line 1139 in order to compare it with the call to `std::unique` in line 1138.
我们应该在 1139 行调用 `mystl::unique` 以与 1138 行的 `std::unique` 调用对比。