### PR TITLE
Fix `address_of` for overloaded `operator&`

### DIFF
--- a/MyTinySTL/memory.h
+++ b/MyTinySTL/memory.h
@@ -17,11 +17,45 @@ namespace mystl
 {
 
 // 获取对象地址
+//   尽可能使用支持 constexpr 的 __builtin_addressof
+#ifdef __has_builtin
+#define MYTINYSTL_HAS_BUITIN_ADDRESSOF __has_builtin(__builtin_addressof)
+#elif __GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__ >=70000
+#define MYTINYSTL_HAS_BUITIN_ADDRESSOF 1
+#elif _MSC_VER >= 1910
+#define MYTINYSTL_HAS_BUITIN_ADDRESSOF 1
+#else 
+#define MYTINYSTL_HAS_BUITIN_ADDRESSOF 0
+#endif
+
+#if MYTINYSTL_HAS_BUITIN_ADDRESSOF
 template <class Tp>
+constexpr Tp* address_of(Tp& value) noexcept
+{
+  return __builtin_addressof(value);
+}
+#else
+// 对于对象类型和函数类型分别使用不同的策略
+template <class Tp, typename std::enable_if<std::is_object<
+    typename std::remove_reference<Tp>::type>::value, int>::type = 0>
+Tp* address_of(Tp& value) noexcept
+{
+  return const_cast<Tp*>(reinterpret_cast<const volatile Tp*>(
+    &reinterpret_cast<const volatile unsigned char&>(value)));
+}
+
+template <class Tp, typename std::enable_if<!std::is_object<
+    typename std::remove_reference<Tp>::type>::value, int>::type = 0>
 constexpr Tp* address_of(Tp& value) noexcept
 {
   return &value;
 }
+#endif
+
+#undef MYTINYSTL_HAS_BUITIN_ADDRESSOF
+
+template <class Tp>
+void address_of(const Tp&&) = delete; // 避免对临时对象取地址
 
 // 获取 / 释放 临时缓冲区
 


### PR DESCRIPTION
Fixes #133.

策略：
- 如果编译器支持 `__builtin_addressof` 则使用；
- 否则，使用 SFINAE
  - 对函数使用内建 `operator&`；
  - 对对象使用 `reinterpret_cast` 到字节类型再取地址的策略（与 `constexpr` 不兼容）。

为了避免 `addressof<const int>(42)` 之类取临时对象的代码通过编译，对右值提供被删除的重载（实现 [LWG2598](https://cplusplus.github.io/LWG/issue2598)）。