### PR TITLE
Implement vector constructor to support single-pass input iterator range

### DIFF
--- a/MyTinySTL/vector.h
+++ b/MyTinySTL/vector.h
@@ -78,16 +78,9 @@ public:
 
   vector(size_type n, const value_type& value)
   { fill_init(n, value); }
-
+  
   template <class Iter, typename std::enable_if<
-    mystl::is_exactly_input_iterator<Iter>::value, int>::type = 0>
-  vector(Iter first, Iter last) 
-  {
-    range_init(first, last, mystl::input_iterator_tag{});
-  }
-
-  template <class Iter, typename std::enable_if<
-    mystl::is_forward_iterator<Iter>::value, int>::type = 0>
+    mystl::is_input_iterator<Iter>::value, int>::type = 0>
   vector(Iter first, Iter last)
   {
     MYSTL_DEBUG(!(last < first));

--- a/MyTinySTL/vector.h
+++ b/MyTinySTL/vector.h
@@ -80,7 +80,17 @@ public:
   { fill_init(n, value); }
 
   template <class Iter, typename std::enable_if<
-    mystl::is_input_iterator<Iter>::value, int>::type = 0>
+    mystl::is_exactly_input_iterator<Iter>::value, int>::type = 0>
+  vector(Iter first, Iter last) 
+  {
+    try_init();
+    for (; first != last; ++first) {
+        emplace_back(*first);
+    }
+  }
+
+  template <class Iter, typename std::enable_if<
+    mystl::is_forward_iterator<Iter>::value, int>::type = 0>
   vector(Iter first, Iter last)
   {
     MYSTL_DEBUG(!(last < first));

--- a/MyTinySTL/vector.h
+++ b/MyTinySTL/vector.h
@@ -83,10 +83,7 @@ public:
     mystl::is_exactly_input_iterator<Iter>::value, int>::type = 0>
   vector(Iter first, Iter last) 
   {
-    try_init();
-    for (; first != last; ++first) {
-        emplace_back(*first);
-    }
+    range_init(first, last, mystl::input_iterator_tag{});
   }
 
   template <class Iter, typename std::enable_if<
@@ -94,12 +91,12 @@ public:
   vector(Iter first, Iter last)
   {
     MYSTL_DEBUG(!(last < first));
-    range_init(first, last);
+    range_init(first, last, iterator_category(first));
   }
 
   vector(const vector& rhs)
   {
-    range_init(rhs.begin_, rhs.end_);
+    range_init(rhs.begin_, rhs.end_, mystl::forward_iterator_tag{});
   }
 
   vector(vector&& rhs) noexcept
@@ -114,7 +111,7 @@ public:
 
   vector(std::initializer_list<value_type> ilist)
   {
-    range_init(ilist.begin(), ilist.end());
+    range_init(ilist.begin(), ilist.end(), mystl::forward_iterator_tag{});
   }
 
   vector& operator=(const vector& rhs);
@@ -298,8 +295,12 @@ private:
   void      init_space(size_type size, size_type cap);
 
   void      fill_init(size_type n, const value_type& value);
+
   template <class Iter>
-  void      range_init(Iter first, Iter last);
+  void      range_init(Iter first, Iter last, input_iterator_tag);
+
+  template <class Iter>
+  void      range_init(Iter first, Iter last, forward_iterator_tag);
 
   void      destroy_and_recover(iterator first, iterator last, size_type n);
 
@@ -611,12 +612,23 @@ fill_init(size_type n, const value_type& value)
 template <class T>
 template <class Iter>
 void vector<T>::
-range_init(Iter first, Iter last)
+range_init(Iter first, Iter last, mystl::forward_iterator_tag)
 {
   const size_type len = mystl::distance(first, last);
   const size_type init_size = mystl::max(len, static_cast<size_type>(16));
   init_space(len, init_size);
   mystl::uninitialized_copy(first, last, begin_);
+}
+
+template <class T>
+template <class Iter>
+void vector<T>::
+range_init(Iter first, Iter last, mystl::input_iterator_tag)
+{
+  try_init();
+  for (; first != last; ++first) {
+    emplace_back(*first);
+  }
 }
 
 // destroy_and_recover 函数

--- a/Test/vector_test.h
+++ b/Test/vector_test.h
@@ -3,10 +3,11 @@
 
 // vector test : 测试 vector 的接口与 push_back 的性能
 
-#include <vector>
+#include <vector> 
 
 #include "../MyTinySTL/vector.h"
 #include "test.h"
+#include "stream_iterator.h"  // 用于测试 input_iterator 迭代器版构造函数
 
 namespace mystl
 {
@@ -32,7 +33,6 @@ void vector_test()
   v8 = v3;
   v9 = std::move(v3);
   v10 = { 1,2,3,4,5,6,7,8,9 };
-
   FUN_AFTER(v1, v1.assign(8, 8));
   FUN_AFTER(v1, v1.assign(a, a + 5));
   FUN_AFTER(v1, v1.emplace(v1.begin(), 0));
@@ -90,6 +90,12 @@ void vector_test()
   FUN_AFTER(v1, v1.shrink_to_fit());
   FUN_VALUE(v1.size());
   FUN_VALUE(v1.capacity());
+
+  std::istringstream is("1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9 1 2 3 4 5 6 7 8 9");
+  mystl::istream_iterator<int> beg{is}, end; 
+  mystl::vector<int> v11{beg, end};
+  COUT(v11);
+
   PASSED;
 #if PERFORMANCE_TEST_ON
   std::cout << "[--------------------- Performance Testing ---------------------]\n";


### PR DESCRIPTION
目前的 vector 实现并不真正支持只能单次使用的 input_iterator，目前的实现本质上要求输入迭代器必须至少是 forward_iterator。这个问题不仅存在于构造函数，也存在于其他接受迭代器range的成员函数如 insert()/assign()，以及其他容器中。

此 PR 只对 vector ctor 增加了 input_iterator 支持。如果仓库作者愿意接受这个特性支持的话，我很乐意在此方向上继续贡献代码。