### PR TITLE
Add support for range assign and insert for input iterator

### DIFF
--- a/Test/vector_test.h
+++ b/Test/vector_test.h
@@ -7,6 +7,7 @@
 
 #include "../MyTinySTL/vector.h"
 #include "test.h"
+#include "stream_iterator.h"
 
 namespace mystl
 {
@@ -90,6 +91,13 @@ void vector_test()
   FUN_AFTER(v1, v1.shrink_to_fit());
   FUN_VALUE(v1.size());
   FUN_VALUE(v1.capacity());
+
+  std::istringstream is1("0 0 0 0");
+  std::istringstream is2("1 2 3 4 5 6 7 8 9"); 
+  v1.assign(mystl::istream_iterator<int>(is1), mystl::istream_iterator<int>());
+  COUT(v1);
+  v1.insert(v1.begin() + 2, mystl::istream_iterator<int>(is2), mystl::istream_iterator<int>());
+  COUT(v1);
   PASSED;
 #if PERFORMANCE_TEST_ON
   std::cout << "[--------------------- Performance Testing ---------------------]\n";


### PR DESCRIPTION
This patch addresses the issue where range assignment and insertion for vector did not support input iterators. With this update, both range assignment and insertion now fully support iterators of the input iterator category. New tests have been added to validate the correctness of the code, and all existing tests have passed successfully. With the prior PR #160 adding support for input iterators for the constructor of vector, this PR extends that support to both range assignment and range insertion.