### PR TITLE
Implement ostream_iterator for MyTinySTL

### DIFF
--- a/MyTinySTL/stream_iterator.h
+++ b/MyTinySTL/stream_iterator.h
@@ -71,10 +71,57 @@ private:
 };
 
 
-// TODO 
-// template<typename T, typename CharT = char,
-//          typename Traits = char_traits<CharT> >
-// class ostream_iterator : public iterator<output_iterator_tag, void, void, void, void> {};
+template<typename T, typename CharT = char,
+        typename Traits = std::char_traits<CharT>>
+class ostream_iterator
+: public iterator<output_iterator_tag, void, void, void, void>
+{
+public:
+    using char_type = CharT;
+    using traits_type = Traits;
+    using ostream_type = std::basic_ostream<CharT, Traits>;
+
+    ostream_iterator()
+        : m_stream(nullptr), m_delimiter(nullptr) {}
+
+    ostream_iterator(ostream_type& os)
+        : m_stream(std::addressof(os)), m_delimiter(nullptr) {}
+
+    ostream_iterator(ostream_type& os, const CharT* delimiter)
+        : m_stream(std::addressof(os)), m_delimiter(delimiter) {}
+
+    ostream_iterator(const ostream_iterator& other)
+        : m_stream(other.m_stream), m_delimiter(other.m_delimiter) {}
+
+    ostream_iterator& operator=(const ostream_iterator&) = default;
+
+    ~ostream_iterator() = default;
+
+    ostream_iterator& operator=(const T& value) {
+        MYSTL_DEBUG(m_stream != nullptr);
+        *m_stream << value;
+        if (m_delimiter) {
+            *m_stream << m_delimiter;
+        }
+        return *this;
+    }
+
+    ostream_iterator& operator*() {
+        return *this;
+    }
+
+    ostream_iterator& operator++() {
+        return *this;
+    }
+
+    ostream_iterator operator++(int) {
+        return *this;
+    }
+
+private:
+    ostream_type* m_stream;
+    const CharT* m_delimiter;
+};
 }
 
 

--- a/Test/iterator_test.h
+++ b/Test/iterator_test.h
@@ -18,18 +18,37 @@ void stream_iterator_test()
   std::cout << "[------------- Run iterator test : stream_iterator--------------]\n";
   std::cout << "[-------------------------- API test ---------------------------]\n";
 
-  static_assert(mystl::is_exactly_input_iterator<mystl::istream_iterator<int>>::value, 
+  static_assert(mystl::is_exactly_input_iterator<mystl::istream_iterator<int>>::value,
                 "istream_iterator must have input_iterator_tag)");
 
-  std::istringstream is("1 2 3");  
-  mystl::istream_iterator<int> first{is}, last;   
+  std::istringstream is("1 2 3");
+  mystl::istream_iterator<int> first{is}, last;
   std::cout << mystl::distance(first, last) << '\n';
 
-  std::istringstream istream("1 2 3 4 5 6");  
-  mystl::istream_iterator<int> beg{istream}, end;  
+  std::istringstream istream("1 2 3 4 5 6");
+  mystl::istream_iterator<int> beg{istream}, end;
   for (; beg != end; ++beg) {
     std::cout << *beg << " ";
   }
+  std::cout << '\n';
+
+  // ostream_iterator test
+  std::cout << "\n[------------------ ostream_iterator test --------------------]\n";
+  std::vector<int> v1{1, 2, 3, 4, 5};
+  std::cout << "Output with delimiter: ";
+  mystl::ostream_iterator<int> out_iter1(std::cout, " ");
+  mystl::copy(v1.begin(), v1.end(), out_iter1);
+  std::cout << '\n';
+
+  std::cout << "Output without delimiter: ";
+  mystl::ostream_iterator<int> out_iter2(std::cout);
+  mystl::copy(v1.begin(), v1.end(), out_iter2);
+  std::cout << '\n';
+
+  std::vector<std::string> v2{"Hello", "World", "MyTinySTL"};
+  std::cout << "String output with delimiter: ";
+  mystl::ostream_iterator<std::string> out_iter3(std::cout, ", ");
+  mystl::copy(v2.begin(), v2.end(), out_iter3);
   std::cout << '\n';
 
   PASSED;


### PR DESCRIPTION
- Completed the TODO in stream_iterator.h
- Added ostream_iterator class with full functionality
  - Supports output to any ostream with optional delimiter
  - Implements output iterator interface correctly
  - Compatible with standard library algorithms
- Added comprehensive tests in iterator_test.h
- Verified with multiple test cases (int, string, with/without delimiter)
